### PR TITLE
Editing link to documentation in README

### DIFF
--- a/README
+++ b/README
@@ -17,7 +17,7 @@ there, before finally saving it back out to the original element.
 
 See PaintbrushJS in action: http://mezzoblue.github.com/PaintbrushJS/demo/
 Usage examples: http://mezzoblue.github.com/PaintbrushJS/demo/usage.html
-Documentation: http://wiki.github.com/mezzoblue/PaintbrushJS/documentation
+Documentation: https://github.com/mezzoblue/PaintbrushJS/wiki/Documentation
 
 
 KNOWN ISSUES


### PR DESCRIPTION
I stumbled upon non-functional link to documentation in README. Fixed it.